### PR TITLE
Remove interim scraper task list from ROADMAP.md

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,10 +1,1 @@
-## Fix: interim scraper drops all but one session per interim meeting
 
-- [ ] Rewrite `scrapeInterimSessionId` in `src/scraper.js` (~line 650) to collect ALL distinct Meetecho player links found on the session page (dedupe by session ID, preserve page order) instead of overwriting on each match; rename to `scrapeInterimSessionIds` and have it return an array of `{sessionId, recordingUrl}` (empty array if none found)
-- [ ] Update `fetchInterimSession` (~line 718, date+group lookup) to use the renamed function and emit one session entry per scraped link instead of assuming exactly one
-- [ ] Update `fetchAllInterimSessions` (~line 755, all groups on a date) the same way: for each meeting slug, push one session entry per Meetecho link found
-- [ ] Update `fetchInterimSessionsInRange` (~line 798), which also calls the single-link scraper today, so it stays consistent with the new multi-link contract
-- [ ] Confirm no output filename / cache key collisions when one meeting slug yields multiple sessions (trace `sessionName`/`sessionId` through `src/index.js` and `src/publisher.js`); today's grouping is already keyed by `sessionId` with sessions grouped by `sessionName` into arrays, so multiple sessions sharing a `sessionName` should already work — do not change naming/filenames for the existing single-session-per-slug case
-- [ ] Add/extend unit tests in `src/scraper.test.js` covering: a session page with two Meetecho links returns both sessions in page order; a page with one link behaves exactly as before (byte-identical); a page with duplicate links to the same session ID is deduped to one entry
-- [ ] Run the full test suite (`npm test`) and confirm it passes
-- [ ] Open a PR against the upstream repo `ekr/auto-minutes` (not the fork) describing the root cause and linking https://github.com/ietf-minutes/ietf-minutes-data/issues/14


### PR DESCRIPTION
Remove the interim scraper task list for clarity.